### PR TITLE
Fix the return type for files read from gzip archives

### DIFF
--- a/opentargets_urlzsource/__init__.py
+++ b/opentargets_urlzsource/__init__.py
@@ -1,3 +1,5 @@
+"""Open URL-referenced files; see the URLZSource class for more details."""
+
 from builtins import object
 
 import functools
@@ -11,27 +13,31 @@ from io import TextIOWrapper
 import requests 
 import requests_file
 
+
 def urllify(string_name):
-    """return a file:// urlified simple path to a file:// is :// is not contained in it"""
+    """Prefix file:// to paths that do not already contain ://."""
     return string_name if '://' in string_name else 'file://' + string_name
 
 
 class URLZSource(object):
-    def __init__(self, filename, *args, **kwargs):
-        """Easy way to open multiple types of URL protocol (e.g. http:// and file://)
-        as well as handling compressed content (e.g. .gz or .zip) if appropriate.
+    """Transparent way to open local, URL-referenced and/or compressed files.
 
-        Just in case you need to use proxies for url use it as normal
+    Can handle multiple types of URL scheme (e.g. http:// and file://),
+    as well as compressed content (e.g. .gz or .zip) if appropriate.
+    """
+
+    def __init__(self, filename, *args, **kwargs):
+        """Set the parameters of the file source to access.
+
+        In case you need to use proxies for url use it as normal
         named arguments to requests.
 
-        >>> # proxies = {}
-        >>> # if Config.HAS_PROXY:
-        ...    # self.proxies = {"http": Config.PROXY,
-        ...                      # "https": Config.PROXY}
-        >>> # with URLZSource('http://var.foo/noname.csv',proxies=proxies).open() as f:
-
+        >>> proxies = {}
+        >>> if Config.HAS_PROXY:
+        ...    self.proxies = {"http": Config.PROXY,
+        ...                    "https": Config.PROXY}
+        >>> with URLZSource('http://var.foo/noname.csv',proxies=proxies).open() as f:
         """
-
         self.logger = logging.getLogger(__name__)
 
         self.filename = urllify(filename)
@@ -40,11 +46,7 @@ class URLZSource(object):
 
     @contextmanager
     def _open_local(self, filename, mode):
-        """
-        This is an internal function to handle opening the temporary file 
-        that the URL has been downloaded to, including handling compression
-        if appropriate
-        """
+        """Open a local file, handling compression if appropriate."""
         open_f = None
 
         if filename.endswith('.gz') or filename.endswith('.gzip'):
@@ -75,11 +77,7 @@ class URLZSource(object):
 
     @contextmanager
     def open(self, mode='r'):
-        """
-        This downloads the URL to a temporary file, naming the file
-        based on the URL. 
-        """
-
+        """Open the file for reading, buffering to a tempfile if needed."""
         if self.filename.startswith('ftp://'):
             raise NotImplementedError('finish ftp')
 

--- a/opentargets_urlzsource/__init__.py
+++ b/opentargets_urlzsource/__init__.py
@@ -48,7 +48,7 @@ class URLZSource(object):
         open_f = None
 
         if filename.endswith('.gz') or filename.endswith('.gzip'):
-            open_f = functools.partial(gzip.open, mode='rb')
+            open_f = functools.partial(gzip.open, mode='rt')
 
         elif filename.endswith('.zip'):
             zipped_data = ZipFile(filename)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,6 @@
 #make sure this matches setup.py extras_require
 
-#transitive pin on pytest to avoid 4.1.0 which is broken
-pytest>=4.0.0,<4.1.0
+pytest
 pytest-cov
 pylint
 tox

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(name=__pkgname__,
         'Programming Language :: Python :: 3'
     ],
     #make sure this matches requirements.dev.txt
-    extras_require={'dev': ['pytest>=4.0.0,<4.1.0',
+    extras_require={'dev': ['pytest',
         'pytest-cov', 'pylint', 'tox', 'codecov', 'pipdeptree']}
 )

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -5,16 +5,19 @@ def test_file():
     with URLZSource('tests/general.txt').open() as source:
         content = source.readlines()
         assert content == ["Foo"]
-        
+
+
 def test_file_gz():
     with URLZSource('tests/general.txt.gz').open() as source:
         content = source.readlines()
         assert content == ["Foo"]
 
-def test_file_gz():
+
+def test_file_zip():
     with URLZSource('tests/general.txt.zip').open() as source:
         content = source.readlines()
         assert content == ["Foo"]
+
 
 def test_url():
     url = "https://raw.githubusercontent.com/opentargets/urlzsource/master/tests/general.txt"
@@ -22,8 +25,8 @@ def test_url():
         content = source.readlines()
         assert content == ["Foo"]
 
+
 def test_file_url():
     with URLZSource('file://./tests/general.txt').open() as source:
         content = source.readlines()
         assert content == ["Foo"]
-        


### PR DESCRIPTION
The code contained a bug that wasn't caught by the tests because of another bug. This made the class return a byte string if the input file was gzip-compressed, while other file types resulted in a character string as of Python 3.

The fix in this pull request changes the return type for gzip input archives, to make them interchangeable with other file types. It will require adjustments to about ten lines of code in the data pipeline, that previously only worked with gzip files.